### PR TITLE
feat(transform): add new input options and return contents

### DIFF
--- a/packages/reiconify/test/__snapshots__/transform.spec.js.snap
+++ b/packages/reiconify/test/__snapshots__/transform.spec.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`transform no files output if shouldWriteFiles to be false 1`] = `[Error: ENOENT: no such file or directory, scandir 'fixtures/transform/src']`;
+
+exports[`transform return promise 1`] = `
+"import React from 'react'
+import Icon from './Icon'
+
+const Check = props => (
+  <Icon width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" {...props}>
+    <path d=\\"M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z\\" />
+  </Icon>
+)
+
+Check.defaultProps = {name: 'Check'}
+
+export default Check
+"
+`;
+
 exports[`transform throws if no inputs 1`] = `[Error: Missing input files]`;
 
 exports[`transform throws if no matched files 1`] = `[Error: Cannot find source files]`;
@@ -140,4 +158,22 @@ exports[`transform transforms icons to src/es/cjs 4`] = `
     d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-1.91l-.01-.01L23 10z"
   />
 </svg>
+`;
+
+exports[`transform use options template 1`] = `
+"import React from 'react'
+import Icon from 'foo'
+
+const Check = props => (
+  <Icon width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" {...props}>
+    <path d=\\"M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z\\" />
+  </Icon>
+)
+
+Check.defaultProps = {name: 'Check'}
+
+export default bar
+
+export const ReactComponent = Check
+"
 `;

--- a/packages/reiconify/test/fixtures/transform/createOptionsTemplate.js
+++ b/packages/reiconify/test/fixtures/transform/createOptionsTemplate.js
@@ -1,0 +1,32 @@
+module.exports = function createTemplate({ baseTemplatePath, filePath }) {
+  return function(data) {
+    const jsxWithProps = data.jsxString
+      .replace(/<svg([\s\S]*?)>/, (match, group) => `<Icon${group} {...props}>`)
+      .replace(/<\/svg>$/, "</Icon>");
+
+    return `
+    import React from 'react'
+    import Icon from '${baseTemplatePath}'
+
+    const ${data.name} = props => ${jsxWithProps}
+
+    ${data.name}.defaultProps = ${JSON.stringify(
+      Object.assign(
+        {
+          name: data.name
+        },
+        data.defaultProps
+      )
+    )}
+    
+    ${
+      filePath
+        ? `
+    export default ${filePath}`
+        : ""
+      }
+    
+    export const ReactComponent = ${data.name}
+  `;
+  };
+};

--- a/packages/reiconify/test/transform.spec.js
+++ b/packages/reiconify/test/transform.spec.js
@@ -37,6 +37,16 @@ describe('transform', () => {
     await expect(transform({inputs: '*.svg'})).rejects.toMatchSnapshot()
   })
 
+  it('return promise', async () => {
+    const [{name, code}] = await transform({
+      inputs: 'fixtures/transform/icons/*.svg',
+      src: true,
+      srcDir,
+    })
+    expect(name).toBeTruthy()
+    expect(code).toMatchSnapshot()
+  })
+
   it('throws if no matched files', async () => {
     await expect(
       transform({inputs: 'xyz.svg', srcDir: 'src'})
@@ -52,6 +62,31 @@ describe('transform', () => {
 
     const files = await promisify(fs.readdir)(srcDir)
     expect(files).toMatchSnapshot()
+  })
+
+  it('no files output if shouldWriteFiles to be false', async () => {
+    await transform({
+      inputs: 'fixtures/transform/icons/*.svg',
+      src: true,
+      srcDir,
+      shouldWriteFiles: false,
+    })
+    expect(promisify(fs.readdir)(srcDir)).rejects.toMatchSnapshot()
+  })
+
+  it('use options template', async () => {
+    const [{code}] = await
+      transform({
+        inputs: 'fixtures/transform/icons/*.svg',
+        src: true,
+        srcDir,
+        shouldWriteFiles: false,
+        template: require('./fixtures/transform/createOptionsTemplate')({
+          baseTemplatePath: 'foo',
+          filePath: 'bar',
+        }),
+      })
+    expect(code).toMatchSnapshot()
   })
 
   it('transforms icons to src/es/cjs', async () => {


### PR DESCRIPTION
1.  Transform will return contents
2. Add two new available members for input param options
    1. shouldShowFiles:  boolean, default true. If value is false, transform will not write files and silent log
    2. template: function. Allow pass a custom template function, if it exist, will override template in reiconify.config.js 