### PR TITLE
fix: disable removeViewBox

### DIFF
--- a/packages/reiconify/lib/svg2jsx.js
+++ b/packages/reiconify/lib/svg2jsx.js
@@ -58,6 +58,7 @@ const camelCaseNamespacedProps = {
 // https://github.com/svg/svgo/issues/646
 // https://github.com/BohemianCoding/svgo-compressor/blob/develop/src/defaultConfig.js
 const getDefaultSvgoPlugins = ({idPrefix}) => [
+  {removeViewBox: false},
   {removeDesc: {removeAny: true}},
   {removeXMLNS: true},
   {sortAttrs: true},

--- a/packages/reiconify/test/__snapshots__/component.spec.jsx.snap
+++ b/packages/reiconify/test/__snapshots__/component.spec.jsx.snap
@@ -19,6 +19,7 @@ exports[`component renders \`center\` and \`style\` prop 1`] = `
         "color": "red",
       }
     }
+    viewBox="0 0 24 24"
     width="24"
   >
     <path
@@ -42,6 +43,7 @@ exports[`component renders \`center\` prop 1`] = `
     className="MyIcon MyIcon--Check"
     fill="currentColor"
     height="24"
+    viewBox="0 0 24 24"
     width="24"
   >
     <path
@@ -56,6 +58,7 @@ exports[`component renders \`className\` prop 1`] = `
   className="MyIcon MyIcon--Check myIcon"
   fill="currentColor"
   height="24"
+  viewBox="0 0 24 24"
   width="24"
 >
   <path
@@ -69,6 +72,7 @@ exports[`component renders \`size\` prop 1`] = `
   className="MyIcon MyIcon--Check"
   fill="currentColor"
   height={20}
+  viewBox="0 0 24 24"
   width={20}
 >
   <path
@@ -91,6 +95,7 @@ exports[`component renders \`text\` and \`center\` prop 1`] = `
     className="MyIcon MyIcon--Check"
     fill="currentColor"
     height="1.2em"
+    viewBox="0 0 24 24"
     width="1.2em"
   >
     <path
@@ -105,6 +110,7 @@ exports[`component renders \`text\` prop 1`] = `
   className="MyIcon MyIcon--Check"
   fill="currentColor"
   height="1.2em"
+  viewBox="0 0 24 24"
   width="1.2em"
 >
   <path
@@ -118,6 +124,7 @@ exports[`component renders \`text\` prop 2`] = `
   className="MyIcon MyIcon--Check"
   fill="currentColor"
   height="24"
+  viewBox="0 0 24 24"
   width="24"
 >
   <path

--- a/packages/reiconify/test/__snapshots__/svg2jsx.spec.js.snap
+++ b/packages/reiconify/test/__snapshots__/svg2jsx.spec.js.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`svg2jsx adds unique id prefix 1`] = `"<svg width=\\"24\\" height=\\"24\\"><defs><linearGradient id=\\"id-2703904526-a\\" x1=\\"63.313%\\" x2=\\"46.604%\\" y1=\\"-13.472%\\" y2=\\"117.368%\\"><stop offset=\\"2.35%\\" stop-color=\\"#EC471E\\"/><stop offset=\\"100%\\" stop-color=\\"#FF6DC4\\"/></linearGradient></defs><path fill=\\"url(#id-2703904526-a)\\" fill-rule=\\"evenodd\\" d=\\"M0 0h24v24H0z\\"/></svg>"`;
+exports[`svg2jsx adds unique id prefix 1`] = `"<svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\"><defs><linearGradient id=\\"id-2703904526-a\\" x1=\\"63.313%\\" x2=\\"46.604%\\" y1=\\"-13.472%\\" y2=\\"117.368%\\"><stop offset=\\"2.35%\\" stop-color=\\"#EC471E\\"/><stop offset=\\"100%\\" stop-color=\\"#FF6DC4\\"/></linearGradient></defs><path fill=\\"url(#id-2703904526-a)\\" fill-rule=\\"evenodd\\" d=\\"M0 0h24v24H0z\\"/></svg>"`;
 
-exports[`svg2jsx converts inline styles to style objects 1`] = `"<svg width=\\"24\\" height=\\"24\\"><path d=\\"M0 0h24v24H0z\\" style={{background:'red'}}/><path d=\\"M0 0h24v24H0z\\" style={{background:'red',mixBlendMode:'overlay'}}/></svg>"`;
+exports[`svg2jsx converts inline styles to style objects 1`] = `"<svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\"><path d=\\"M0 0h24v24H0z\\" style={{background:'red'}}/><path d=\\"M0 0h24v24H0z\\" style={{background:'red',mixBlendMode:'overlay'}}/></svg>"`;
 
-exports[`svg2jsx converts namespaced attrs to camel case 1`] = `"<svg width=\\"24\\" height=\\"24\\" xmlnsXlink=\\"http://www.w3.org/1999/xlink\\"><path id=\\"id-2183265438-a\\" d=\\"M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z\\"/><use xlinkHref=\\"#id-2183265438-a\\"/></svg>"`;
+exports[`svg2jsx converts namespaced attrs to camel case 1`] = `"<svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" xmlnsXlink=\\"http://www.w3.org/1999/xlink\\"><path id=\\"id-2183265438-a\\" d=\\"M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z\\"/><use xlinkHref=\\"#id-2183265438-a\\"/></svg>"`;
 
-exports[`svg2jsx converts svg to jsx (React <= 15) 1`] = `"<svg width=\\"24\\" height=\\"24\\"><path d=\\"M0 0h24v24H0z\\" fillOpacity=\\".5\\" pointerEvents=\\"none\\"/></svg>"`;
+exports[`svg2jsx converts svg to jsx (React <= 15) 1`] = `"<svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\"><path d=\\"M0 0h24v24H0z\\" fillOpacity=\\".5\\" pointerEvents=\\"none\\"/></svg>"`;
 
-exports[`svg2jsx converts svg to jsx 1`] = `"<svg width=\\"24\\" height=\\"24\\"><path fill-opacity=\\".5\\" d=\\"M0 0h24v24H0z\\" pointer-events=\\"none\\"/></svg>"`;
+exports[`svg2jsx converts svg to jsx 1`] = `"<svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\"><path fill-opacity=\\".5\\" d=\\"M0 0h24v24H0z\\" pointer-events=\\"none\\"/></svg>"`;
 
-exports[`svg2jsx reuses svgo instance 1`] = `"<svg width=\\"24\\" height=\\"24\\"><path d=\\"M0 0h24v24H0z\\" pointerEvents=\\"none\\"/></svg>"`;
+exports[`svg2jsx reuses svgo instance 1`] = `"<svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\"><path d=\\"M0 0h24v24H0z\\" pointerEvents=\\"none\\"/></svg>"`;
 
 exports[`svg2jsx uses \`removeAttrs\` plugin 1`] = `"<svg><path fill=\\"red\\" stroke=\\"red\\" d=\\"M0 0h24v24H0z\\"/></svg>"`;
 

--- a/packages/reiconify/test/__snapshots__/transform.spec.js.snap
+++ b/packages/reiconify/test/__snapshots__/transform.spec.js.snap
@@ -5,7 +5,7 @@ exports[`component transforms svg 1`] = `
 import SVG from './Icon'
 
 const Icon = (props) => (
-  <SVG width=\\"24\\" height=\\"24\\" {...props}>
+  <SVG width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" {...props}>
     <path d=\\"M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z\\" />
   </SVG>
 )
@@ -26,6 +26,7 @@ const Heart = (props) =>
         {
           width: '24',
           height: '24',
+          viewBox: '0 0 24 24',
         },
         props
       ),
@@ -51,6 +52,7 @@ const Heart = (props) => (
   <SVG
     width=\\"24\\"
     height=\\"24\\"
+    viewBox=\\"0 0 24 24\\"
     {...props}
     className={
       'Mdi Mdi--Heart' + (props.className ? \` \${props.className}\` : '')
@@ -69,7 +71,7 @@ exports[`component transforms svg with options 1`] = `
 import SVG from 'base-icon'
 
 const Component = (props) => (
-  <SVG width=\\"24\\" height=\\"24\\" {...props}>
+  <SVG width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" {...props}>
     <path d=\\"M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z\\" />
   </SVG>
 )

--- a/packages/reiconify/test/__snapshots__/transformFiles.spec.js.snap
+++ b/packages/reiconify/test/__snapshots__/transformFiles.spec.js.snap
@@ -55,6 +55,7 @@ exports[`transform transforms icons to src/es/cjs 2`] = `
 <svg
   fill="currentColor"
   height="24"
+  viewBox="0 0 24 24"
   width="24"
 >
   <path
@@ -67,6 +68,7 @@ exports[`transform transforms icons to src/es/cjs 3`] = `
 <svg
   fill="currentColor"
   height="20"
+  viewBox="0 0 19 20"
   width="19"
 >
   <defs>
@@ -128,6 +130,7 @@ exports[`transform transforms icons to src/es/cjs 4`] = `
 <svg
   fill="currentColor"
   height="24"
+  viewBox="0 0 24 24"
   width="24"
 >
   <path


### PR DESCRIPTION
相关：
- https://github.com/ambar/reiconify/pull/16 —— 撤销它升级带来的 breaking change
- https://github.com/svg/svgo/blob/master/plugins/removeViewBox.js

这会使 md.icons/transform API 不工作，因为图标要 runtime 自适应大小（动态传递 width/height），构建时分析 width/height 是否与 viewbox 一样去除是不合适的。