### PR TITLE
fix: make transform compatible with ES5

### DIFF
--- a/packages/reiconify/lib/defaultConfig.js
+++ b/packages/reiconify/lib/defaultConfig.js
@@ -17,7 +17,9 @@ const template = (data) => {
     import React from 'react'
     import SVG from '${data.baseName}'
 
-    const ${data.name} = props => ${jsxWithProps}
+    function ${data.name}(props) {
+      return ${jsxWithProps}
+    }
 
     ${
       data.defaultProps && Object.keys(data.defaultProps).length

--- a/packages/reiconify/test/__snapshots__/transform.spec.js.snap
+++ b/packages/reiconify/test/__snapshots__/transform.spec.js.snap
@@ -4,11 +4,13 @@ exports[`component transforms svg 1`] = `
 "import React from 'react'
 import SVG from './Icon'
 
-const Icon = (props) => (
-  <SVG width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" {...props}>
-    <path d=\\"M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z\\" />
-  </SVG>
-)
+function Icon(props) {
+  return (
+    <SVG width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" {...props}>
+      <path d=\\"M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z\\" />
+    </SVG>
+  )
+}
 
 export default Icon
 "
@@ -18,8 +20,8 @@ exports[`component transforms svg to ESM format 1`] = `
 "var __assign = Object.assign
 import React from 'react'
 import SVG from './Icon'
-const Heart = (props) =>
-  /* @__PURE__ */ React.createElement(
+function Heart(props) {
+  return /* @__PURE__ */ React.createElement(
     SVG,
     __assign(
       __assign(
@@ -39,6 +41,7 @@ const Heart = (props) =>
       d: 'M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z',
     })
   )
+}
 var stdin_default = Heart
 export {stdin_default as default}
 "
@@ -48,19 +51,21 @@ exports[`component transforms svg with baseClassName 1`] = `
 "import React from 'react'
 import SVG from './Icon'
 
-const Heart = (props) => (
-  <SVG
-    width=\\"24\\"
-    height=\\"24\\"
-    viewBox=\\"0 0 24 24\\"
-    {...props}
-    className={
-      'Mdi Mdi--Heart' + (props.className ? \` \${props.className}\` : '')
-    }
-  >
-    <path d=\\"M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z\\" />
-  </SVG>
-)
+function Heart(props) {
+  return (
+    <SVG
+      width=\\"24\\"
+      height=\\"24\\"
+      viewBox=\\"0 0 24 24\\"
+      {...props}
+      className={
+        'Mdi Mdi--Heart' + (props.className ? \` \${props.className}\` : '')
+      }
+    >
+      <path d=\\"M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z\\" />
+    </SVG>
+  )
+}
 
 export default Heart
 "
@@ -70,11 +75,13 @@ exports[`component transforms svg with options 1`] = `
 "import React from 'react'
 import SVG from 'base-icon'
 
-const Component = (props) => (
-  <SVG width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" {...props}>
-    <path d=\\"M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z\\" />
-  </SVG>
-)
+function Component(props) {
+  return (
+    <SVG width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" {...props}>
+      <path d=\\"M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z\\" />
+    </SVG>
+  )
+}
 
 Component.defaultProps = {width: 24, height: 24}
 


### PR DESCRIPTION
transform 样例：

```js
var __assign = Object.assign;
import React from "react";
import SVG from "./Icon";
const WatchLater = (props) => /* @__PURE__ */ React.createElement(SVG, __assign(__assign({}, props), {
  className: "Mdi Mdi--WatchLater" + (props.className ? ` ${props.className}` : "")
}), /* @__PURE__ */ React.createElement("path", {
  d: "M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm4.2 14.2L11 13V7h1.5v5.2l4.5 2.7-.8 1.3z"
}));
```