### PR TITLE
feat: add template for index file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist
 # Files
 *.log
 .DS_Store
+
+# webstorm
+.idea

--- a/packages/reiconify/lib/defaultConfig.js
+++ b/packages/reiconify/lib/defaultConfig.js
@@ -86,6 +86,14 @@ const baseDefaultProps = {
 
 const filenameTemplate = (name) => pascalCase(name).replace(/_/g, '')
 
+const indexTemplate = (names) => {
+  names = names.slice().sort()
+  const lines = names.map(
+    (name) => `export {default as ${name}} from './${name}'`
+  )
+  return lines.join('\n')
+}
+
 const defaults = {
   name: 'Icon',
   baseName: './Icon',
@@ -95,6 +103,7 @@ const defaults = {
   defaultProps: {},
   baseDefaultProps,
   filenameTemplate,
+  indexTemplate,
   svgoPlugins: [],
   camelCaseProps: true,
 }

--- a/packages/reiconify/lib/transformFiles.js
+++ b/packages/reiconify/lib/transformFiles.js
@@ -9,13 +9,9 @@ const resolveConfig = require('./resolveConfig')
 const transform = require('./transform')
 const esTransform = require('./esTransform')
 
-const getIndex = async (names) => {
-  names = names.slice().sort()
-  const lines = names.map(
-    (name) => `export {default as ${name}} from './${name}'`
-  )
+const getIndex = (names, {indexTemplate}) => {
   log(`exporting ${names.length} icons: ${names.join(', ')}`)
-  return prettier(lines.join('\n'))
+  return prettier(indexTemplate(names))
 }
 
 const writeFiles = async (contents, path) => {
@@ -68,6 +64,7 @@ const transformFiles = async (options = {}) => {
     defaultProps,
     baseDefaultProps,
     filenameTemplate,
+    indexTemplate,
     svgoPlugins,
     camelCaseProps,
   } = await resolveConfig(cwd)
@@ -99,7 +96,7 @@ const transformFiles = async (options = {}) => {
       name: 'Icon',
       code: prettier(baseTemplate({baseDefaultProps})),
     },
-    {name: 'index', code: await getIndex(namesToExport)}
+    {name: 'index', code: await getIndex(namesToExport, {indexTemplate})}
   )
 
   const operations = [

--- a/packages/reiconify/test/__snapshots__/resolve-config.spec.js.snap
+++ b/packages/reiconify/test/__snapshots__/resolve-config.spec.js.snap
@@ -11,6 +11,7 @@ Object {
   "camelCaseProps": true,
   "defaultProps": Object {},
   "filenameTemplate": [Function],
+  "indexTemplate": [Function],
   "name": "Icon",
   "svgoPlugins": Array [],
   "template": [Function],
@@ -28,6 +29,7 @@ Object {
   "camelCaseProps": true,
   "defaultProps": Object {},
   "filenameTemplate": [Function],
+  "indexTemplate": [Function],
   "name": "Icon",
   "svgoPlugins": Array [
     Object {


### PR DESCRIPTION
- add indexTemplate as a config option
- test snapshot updated
 

indexTemplate can be used to manipulate index file of the output.